### PR TITLE
Using internal IP and port in LB instead of URL exposed

### DIFF
--- a/diffusion_with_autoscaler/autoscaler.py
+++ b/diffusion_with_autoscaler/autoscaler.py
@@ -424,8 +424,8 @@ class _LoadBalancer(LightningWork):
                 headers={"WWW-Authenticate": "Basic"},
             ) from e
 
-        if not self.load_balancer._internal_ip:
-            return 0
+        if not self._internal_ip:
+            return
 
         headers = {
             "accept": "application/json",

--- a/diffusion_with_autoscaler/autoscaler.py
+++ b/diffusion_with_autoscaler/autoscaler.py
@@ -423,6 +423,10 @@ class _LoadBalancer(LightningWork):
                 detail="Invalid authentication credentials",
                 headers={"WWW-Authenticate": "Basic"},
             ) from e
+
+        if not self.load_balancer._internal_ip:
+            return 0
+
         headers = {
             "accept": "application/json",
             "username": USERNAME,
@@ -695,6 +699,8 @@ class AutoScaler(LightningFlow):
     @property
     def num_pending_requests(self) -> int:
         """Fetches the number of pending requests via load balancer."""
+        if not self.load_balancer._internal_ip:
+            return 0
         return int(requests.get(f"http://{self.load_balancer._internal_ip}:{self.load_balancer._port}/num-requests").json())
 
     @property

--- a/diffusion_with_autoscaler/datatypes.py
+++ b/diffusion_with_autoscaler/datatypes.py
@@ -28,7 +28,14 @@ response = requests.post('"""
             + url
             + """', json={
 "image": img
-})"""
+})
+# If you are using basic authentication for your app, you should add your credentials to the request:
+# response = requests.post('"""
+            + url
+            + """', json={
+# "image": img
+# }, auth=requests.auth.HTTPBasicAuth('your_username', 'your_password'))
+"""
         )
 
     @staticmethod
@@ -58,6 +65,12 @@ response = requests.post('"""
             + """', json={
 "text": "A portrait of a person looking away from the camera"
 })
+# If you are using basic authentication for your app, you should add your credentials to the request:
+# response = requests.post('"""
+            + url
+            + """', json={
+# "text": "A portrait of a person looking away from the camera"
+# }, auth=requests.auth.HTTPBasicAuth('your_username', 'your_password'))
 """
         )
 
@@ -77,6 +90,12 @@ response = requests.post('"""
                 + """', json={
 "inputs": [{"text": "A portrait of a person looking away from the camera"}]
 })
+# If you are using basic authentication for your app, you should add your credentials to the request:
+# response = requests.post('"""
+                + url
+                + """', json={
+# "inputs": [{"text": "A portrait of a person looking away from the camera"}],
+# }, auth=requests.auth.HTTPBasicAuth('your_username', 'your_password'))
 """
         )
 


### PR DESCRIPTION
The change:
- In a Load Balancer, use internal IP + port access to avoid making requests via ingress (as we do now). This is needed to make its work with auth-protected apps possible.
- Updates code examples: now the info on how to access to the basic auth-protected app is added.

This PR includes changes from these PRs from the lightning repo:
- https://github.com/Lightning-AI/lightning/pull/16119
- https://github.com/Lightning-AI/lightning/pull/16145